### PR TITLE
update swagger.py

### DIFF
--- a/wordnik/swagger.py
+++ b/wordnik/swagger.py
@@ -144,7 +144,7 @@ class ApiClient:
             # Server will always return a time stamp in UTC, but with
             # trailing +0000 indicating no offset from UTC. So don't process
             # last 5 characters.
-            return datetime.datetime.strptime(obj[:-5],
+            return datetime.datetime.strptime(obj[:-3],
                                               "%Y-%m-%dT%H:%M:%S.%f")
 
         instance = objClass()


### PR DESCRIPTION
The server returns datetimes in the format "2025-03-02T03:00:00.000Z", only the last 3 characters need to be excluded from parsing. This change doesn't break other APIs like the definitions one for example.
Fixes #16 